### PR TITLE
Fixed total_space_formatted TB calculation formula

### DIFF
--- a/SQLWATCHDB/dbo/Views/vw_sqlwatch_report_dim_os_volume.sql
+++ b/SQLWATCHDB/dbo/Views/vw_sqlwatch_report_dim_os_volume.sql
@@ -62,7 +62,7 @@
 			when volume_total_space_bytes_current / 1024.0 < 1000 then convert(varchar(100),convert(decimal(10,2),volume_total_space_bytes_current / 1024.0 )) + ' KB'
 			when volume_total_space_bytes_current / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(10,2),volume_total_space_bytes_current / 1024.0 / 1024.0)) + ' MB'
 			when volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(10,2),volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0)) + ' GB' 
-			else convert(varchar(100),convert(decimal(10,2),volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0)) + ' TB' 
+			else convert(varchar(100),convert(decimal(10,2),volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0 / 1024.0)) + ' TB' 
 			end
 	, [free_space_formatted] = case
 			when [volume_free_space_bytes_current] / 1024.0 < 1000 then convert(varchar(100),convert(decimal(10,2),[volume_free_space_bytes_current] / 1024.0 )) + ' KB'


### PR DESCRIPTION
My 1 TB drive was getting overflow in 2.1. Noticed you fixed it in 2.2 but I was getting 1024 TB instead of 1.00 TB. Noticed your forgot one division.