### PR TITLE
Use a dynamic path for the msdb dacpac to enable building the project from environments other than Visual Studio 2019

### DIFF
--- a/SQLWATCHDB/SQLWATCH.sqlproj
+++ b/SQLWATCHDB/SQLWATCH.sqlproj
@@ -295,8 +295,8 @@
     <PreDeploy Include="Script.PreDeployment2.sql" />
   </ItemGroup>
   <ItemGroup>
-    <ArtifactReference Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\Extensions\Microsoft\SQLDB\Extensions\SqlServer\110\SqlSchemas\msdb.dacpac">
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\Extensions\Microsoft\SQLDB\Extensions\SqlServer\110\SqlSchemas\msdb.dacpac</HintPath>
+    <ArtifactReference Include="$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\110\SqlSchemas\msdb.dacpac">
+      <HintPath>$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\110\SqlSchemas\msdb.dacpac</HintPath>
       <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
       <DatabaseVariableLiteralValue>msdb</DatabaseVariableLiteralValue>
     </ArtifactReference>


### PR DESCRIPTION
Use a dynamic path for the msdb dacpac to enable building the project from environments other than Visual Studio 2019

This is in reference to issue #136 