### PR TITLE
Bug Fix [vw_sqlwatch_report_dim_os_volume.sql]

### DIFF
--- a/SQLWATCHDB/dbo/Views/vw_sqlwatch_report_dim_os_volume.sql
+++ b/SQLWATCHDB/dbo/Views/vw_sqlwatch_report_dim_os_volume.sql
@@ -59,24 +59,24 @@
 		, [volume_total_space_bytes_current], [volume_free_space_bytes_current], [volume_bytes_growth], [total_growth_days], [free_space_percentage]
 		, [growth_bytes_per_day], [days_until_full]
 	, [total_space_formatted] = case 
-			when volume_total_space_bytes_current / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),volume_total_space_bytes_current / 1024.0 )) + ' KB'
-			when volume_total_space_bytes_current / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),volume_total_space_bytes_current / 1024.0 / 1024.0)) + ' MB'
-			when volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0)) + ' GB' 
-			else convert(varchar(100),convert(decimal(5,2),volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0)) + ' TB' 
+			when volume_total_space_bytes_current / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),volume_total_space_bytes_current / 1024.0 )) + ' KB'
+			when volume_total_space_bytes_current / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),volume_total_space_bytes_current / 1024.0 / 1024.0)) + ' MB'
+			when volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0)) + ' GB' 
+			else convert(varchar(100),convert(decimal(6,2),volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0 / 1024.0)) + ' TB' 
 			end
 	, [free_space_formatted] = case
-			when [volume_free_space_bytes_current] / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),[volume_free_space_bytes_current] / 1024.0 )) + ' KB'
-			when [volume_free_space_bytes_current] / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),[volume_free_space_bytes_current] / 1024.0 / 1024.0)) + ' MB'
-			when [volume_free_space_bytes_current] / 1024.0 / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),[volume_free_space_bytes_current] / 1024.0 / 1024.0 / 1024.0)) + ' GB' 
-			else convert(varchar(100),convert(decimal(5,2),[volume_free_space_bytes_current] / 1024.0 / 1024.0 / 1024.0 / 1024.0)) + ' TB' 
+			when [volume_free_space_bytes_current] / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),[volume_free_space_bytes_current] / 1024.0 )) + ' KB'
+			when [volume_free_space_bytes_current] / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),[volume_free_space_bytes_current] / 1024.0 / 1024.0)) + ' MB'
+			when [volume_free_space_bytes_current] / 1024.0 / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),[volume_free_space_bytes_current] / 1024.0 / 1024.0 / 1024.0)) + ' GB' 
+			else convert(varchar(100),convert(decimal(6,2),[volume_free_space_bytes_current] / 1024.0 / 1024.0 / 1024.0 / 1024.0)) + ' TB' 
 			end
 
 	, [growth_bytes_per_day_formatted] = case
-			when growth_bytes_per_day / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),growth_bytes_per_day / 1024.0 )) + ' KB / Day'
-			when growth_bytes_per_day / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),growth_bytes_per_day / 1024.0 / 1024.0)) + ' MB / Day'
-			when growth_bytes_per_day / 1024.0 / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(5,2),growth_bytes_per_day / 1024.0 / 1024.0 / 1024.0)) + ' GB / Day' 
+			when growth_bytes_per_day / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),growth_bytes_per_day / 1024.0 )) + ' KB / Day'
+			when growth_bytes_per_day / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),growth_bytes_per_day / 1024.0 / 1024.0)) + ' MB / Day'
+			when growth_bytes_per_day / 1024.0 / 1024.0 / 1024.0 < 1000 then convert(varchar(100),convert(decimal(6,2),growth_bytes_per_day / 1024.0 / 1024.0 / 1024.0)) + ' GB / Day' 
 			else convert(varchar(100),convert(decimal(5,2),growth_bytes_per_day / 1024.0 / 1024.0 / 1024.0 / 1024.0)) + ' TB' 
 			end
-	, [free_space_percentage_formatted] = convert(varchar(50),convert(decimal(5,0),volume_free_space_bytes_current * 1.0 / volume_total_space_bytes_current  * 100.0)) + ' %'
+	, [free_space_percentage_formatted] = convert(varchar(50),convert(decimal(6,0),volume_free_space_bytes_current * 1.0 / volume_total_space_bytes_current  * 100.0)) + ' %'
 	from cte_volume_growth
 


### PR DESCRIPTION
Calculate TB in [total_space_formated] + consider 1000GB GPT Drives with reserved Partition

1) Row 65:  add / 1024.0: volume_total_space_bytes_current / 1024.0 / 1024.0 / 1024.0 / 1024.0)) + ' TB'
2) Row 62-80 1000GB GPT formated VMWARE Drive will schown with 999.9970664978027343 GB ~ 1000.00 GB not as 1,00 TB
this will end in Arithmetic overflow error converting numeric to data type numeric.
Solution: Change CONVERT(DECIMAL(5, 2) to CONVERT(DECIMAL(6, 2)


TOTAL_SPACE_unforamted	sql_instance	sqlwatch_volume_id	volume_name	label	file_system	volume_block_size_bytes	date_added	date_updated	last_seen	volume_total_space_bytes_current	volume_free_space_bytes_current	volume_bytes_growth	total_growth_days	free_space_percentage	growth_bytes_per_day	days_until_full	total_space_formatted	free_space_formatted	growth_bytes_per_day_formatted	free_space_percentage_formatted
999.9970664978027343	<Instance>	4	G:\	Backups	NTFS	4096	2020-02-10 09:04:42.127	NULL	2020-02-20 13:04:40.387	1073738674176	401328832512	-1913237504	10	0.37376769801086338	0	0	1000.00 GB	373.77 GB	0.00 KB / Day	37 %