### PR TITLE
Enable capture of system configuration

### DIFF
--- a/SQLWATCHDB/SQLWATCH.sqlproj
+++ b/SQLWATCHDB/SQLWATCH.sqlproj
@@ -283,6 +283,12 @@
     <Build Include="dbo\Tables\sqlwatch_meta_errorlog_keyword.sql" />
     <Build Include="dbo\Procedures\usp_sqlwatch_logger_errorlog.sql" />
     <Build Include="dbo\Views\vw_sqlwatch_logger_errorlog.sql" />
+    <Build Include="dbo\Tables\sqlwatch_logger_system_configuration.sql" />
+    <Build Include="dbo\Tables\sqlwatch_meta_system_configuration.sql" />
+    <Build Include="dbo\Tables\sqlwatch_logger_system_configuration_scd.sql" />
+    <Build Include="dbo\Procedures\usp_sqlwatch_internal_add_system_configuration.sql" />
+    <Build Include="dbo\Views\vw_sqlwatch_sys_configurations.sql" />
+    <Build Include="dbo\Procedures\usp_sqlwatch_logger_system_configuration.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />

--- a/SQLWATCHDB/Scripts/Post-Deployment/Reference-Data/Script.PostDeployment-LoadConfig-SnapshotTypes.sql
+++ b/SQLWATCHDB/Scripts/Post-Deployment/Reference-Data/Script.PostDeployment-LoadConfig-SnapshotTypes.sql
@@ -67,6 +67,9 @@ using (
 	union
 	/* Errorlog */
 	select [snapshot_type_id] = 25, [snapshot_type_desc] = 'ERRORLOG', [snapshot_retention_days] = 30
+	UNION
+	/* System Configuration */
+	select [snapshot_type_id] = 26, [snapshot_type_desc] = 'System Configuration', [snapshot_retention_days] = 365 
 
 ) as source
 on (source.[snapshot_type_id] = target.[snapshot_type_id])

--- a/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_config_create_default_agent_jobs.sql
+++ b/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_config_create_default_agent_jobs.sql
@@ -97,7 +97,8 @@ insert into ##sqlwatch_jobs
 			('SQLWATCH-REPORT-AZMONITOR',		4,			1,				4,					10,						0,						1,							20180101,			99991231,			21,					235959,				1),
 			('SQLWATCH-LOGGER-WHOISACTIVE',		4,			1,				2,					15,						0,						0,							20180101,			99991231,			0,					235959,				@enabled),
 
-			('SQLWATCH-INTERNAL-CHECKS',		4,			1,				4,					1,						0,						1,							20180101,			99991231,			43,					235959,				1)
+			('SQLWATCH-INTERNAL-CHECKS',		4,			1,				4,					1,						0,						1,							20180101,			99991231,			43,					235959,				1),
+			('SQLWATCH-LOGGER-CONFIG',		4,			1,				1,					1,						0,						1,							20180101,			99991231,			0,					235959,				1)
 
 			--('SQLWATCH-USER-REPORTS',			4,		1,			1,				0,				0,					1,					20180101,	99991231, 80000,		235959,		1)
 
@@ -210,7 +211,10 @@ Get-WMIObject Win32_Volume | ?{$_.DriveType -eq 3} | %{
 			('dbo.usp_sqlwatch_internal_add_master_file',			4,	'SQLWATCH-INTERNAL-CONFIG','TSQL', 'exec dbo.usp_sqlwatch_internal_add_master_file'),
 			('dbo.usp_sqlwatch_internal_add_wait_type',				5,	'SQLWATCH-INTERNAL-CONFIG','TSQL', 'exec dbo.usp_sqlwatch_internal_add_wait_type'),
 			('dbo.usp_sqlwatch_internal_add_memory_clerk',			6,	'SQLWATCH-INTERNAL-CONFIG','TSQL', 'exec dbo.usp_sqlwatch_internal_add_memory_clerk'),
-			('dbo.usp_sqlwatch_internal_add_table',					7,	'SQLWATCH-INTERNAL-CONFIG','TSQL', 'exec dbo.usp_sqlwatch_internal_add_table')
+			('dbo.usp_sqlwatch_internal_add_table',					7,	'SQLWATCH-INTERNAL-CONFIG','TSQL', 'exec dbo.usp_sqlwatch_internal_add_table'),
+			
+			('dbo.usp_sqlwatch_internal_add_system_configuration',	1,	'SQLWATCH-LOGGER-CONFIG','TSQL', 'exec dbo.usp_sqlwatch_internal_add_system_configuration'),
+			('dbo.usp_sqlwatch_logger_system_configuration',	    2,	'SQLWATCH-LOGGER-CONFIG','TSQL', 'exec dbo.usp_sqlwatch_logger_system_configuration')
 
 
 	exec [dbo].[usp_sqlwatch_internal_create_agent_job]

--- a/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_internal_add_system_configuration.sql
+++ b/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_internal_add_system_configuration.sql
@@ -1,0 +1,31 @@
+﻿CREATE PROCEDURE [dbo].[usp_sqlwatch_internal_add_system_configuration]
+as
+
+merge [dbo].[sqlwatch_meta_system_configuration] as target
+using (
+		select [sql_instance]
+		     , [configuration_id]
+			 , [name]
+			 , [value]
+			 , [value_in_use]
+			 , [description]
+		from dbo.vw_sqlwatch_sys_configurations
+		) as source
+on target.configuration_id = source.configuration_id
+and target.[sql_instance] = source.[sql_instance]
+
+when matched then 
+	update set [value] = source.[value],
+		[value_in_use] = source.[value_in_use],
+		[date_updated] = case when 		
+									target.[value] <> source.[value]
+								or	target.[value_in_use] <> source.[value_in_use]
+								then GETUTCDATE() else [date_updated] end,
+		[date_last_seen] = GETUTCDATE(),
+		[is_record_deleted] = 0
+
+when not matched by target then
+	insert ([sql_instance], [configuration_id], [name], [description], [value], [value_in_use], [date_created], [date_last_seen])
+	values (source.[sql_instance], source.[configuration_id], source.[name], source.[description], source.[value], source.[value_in_use], GETUTCDATE(), GETUTCDATE());
+
+

--- a/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_logger_system_configuration.sql
+++ b/SQLWATCHDB/dbo/Procedures/usp_sqlwatch_logger_system_configuration.sql
@@ -1,0 +1,74 @@
+﻿CREATE PROCEDURE [dbo].[usp_sqlwatch_logger_system_configuration]
+AS
+
+/*
+-------------------------------------------------------------------------------------------------------------------
+ Procedure:
+	[usp_sqlwatch_logger_system_configuration]
+
+ Description:
+	Log system configuration into tables.
+
+ Parameters
+	N/A
+	
+ Author:
+	Fabian Schenker
+
+ Change Log:
+	1.0		2020-05-13	- Fabian Schenker, Initial version
+-------------------------------------------------------------------------------------------------------------------
+*/
+
+set nocount on ;
+set xact_abort on;
+
+declare @snapshot_time datetime2(0),
+		@snapshot_type_id tinyint = 26,
+		@date_snapshot_previous datetime2(0)
+
+select @date_snapshot_previous = max([snapshot_time])
+	from [dbo].[sqlwatch_logger_snapshot_header] (nolock) --so we dont get blocked by central repository. this is safe at this point.
+	where snapshot_type_id = @snapshot_type_id
+	and sql_instance = @@SERVERNAME
+
+	exec [dbo].[usp_sqlwatch_internal_insert_header] 
+		@snapshot_time_new = @snapshot_time OUTPUT,
+		@snapshot_type_id = @snapshot_type_id
+
+
+INSERT INTO [dbo].[sqlwatch_logger_system_configuration] (sql_instance, sqlwatch_configuration_id, value, value_in_use, snapshot_time, snapshot_Type_id)
+SELECT v.sql_instance, m.sqlwatch_configuration_id, v.value, v.value_in_use, @snapshot_time, @snapshot_type_id
+  FROM dbo.vw_sqlwatch_sys_configurations v
+ INNER JOIN dbo.[sqlwatch_meta_system_configuration] m
+    ON v.configuration_id = m.configuration_id
+   AND v.sql_instance = m.sql_instance
+
+
+-- Slowly Changing Dimension for System Configuration
+
+-- Set valid_until for changed or deleted:
+UPDATE curr
+   SET curr.valid_until = @snapshot_time
+  FROM [dbo].[sqlwatch_logger_system_configuration_scd] curr
+  LEFT JOIN (SELECT v.sql_instance, m.sqlwatch_configuration_id, v.value, v.value_in_use
+               FROM dbo.vw_sqlwatch_sys_configurations v
+              INNER JOIN dbo.[sqlwatch_meta_system_configuration] m
+                 ON v.configuration_id = m.configuration_id
+                AND v.sql_instance = m.sql_instance) n
+   ON curr.sql_instance = n.sql_instance
+  AND curr.sqlwatch_configuration_id = n.sqlwatch_configuration_id
+ WHERE n.sql_instance IS NULL OR curr.value <> n.value OR curr.value_in_use <> n.value_in_use
+
+-- Add the new ones or the changed:
+INSERT INTO [dbo].[sqlwatch_logger_system_configuration_scd] (sql_instance, sqlwatch_configuration_id, value, value_in_use, valid_from, valid_until)
+SELECT v.sql_instance, m.sqlwatch_configuration_id, v.value, v.value_in_use, @snapshot_time, NULL
+  FROM dbo.vw_sqlwatch_sys_configurations v
+ INNER JOIN dbo.[sqlwatch_meta_system_configuration] m
+    ON v.configuration_id = m.configuration_id
+   AND v.sql_instance = m.sql_instance
+ LEFT JOIN [dbo].[sqlwatch_logger_system_configuration_scd] curr
+   ON curr.sql_instance = v.sql_instance
+  AND curr.sqlwatch_configuration_id = m.sqlwatch_configuration_id
+WHERE curr.sql_instance IS NULL OR curr.value <> v.value OR curr.value_in_use <> v.value_in_use
+

--- a/SQLWATCHDB/dbo/Tables/sqlwatch_logger_system_configuration.sql
+++ b/SQLWATCHDB/dbo/Tables/sqlwatch_logger_system_configuration.sql
@@ -1,0 +1,17 @@
+﻿CREATE TABLE [dbo].[sqlwatch_logger_system_configuration]
+(
+	sql_instance varchar(32) not null default @@SERVERNAME,
+	sqlwatch_configuration_id smallint not null,
+	value int not null,
+	value_in_use int not null,
+	snapshot_time datetime2(0),
+	snapshot_type_id tinyint default(26),
+	constraint pk_sqlwatch_logger_system_configuration primary key clustered (
+		sqlwatch_configuration_id, snapshot_time, snapshot_type_id
+		),
+	constraint fk_sqlwatch_logger_system_configuration_keyword foreign key (sql_instance, sqlwatch_configuration_id) 
+		references dbo.sqlwatch_meta_system_configuration (sql_instance, sqlwatch_configuration_id)on delete cascade,
+	constraint fk_sqlwatch_logger_system_configuration_snapshot foreign key ([snapshot_time], [sql_instance], [snapshot_type_id])
+		references dbo.sqlwatch_logger_snapshot_header ([snapshot_time], [sql_instance], [snapshot_type_id]) on delete cascade
+)
+go

--- a/SQLWATCHDB/dbo/Tables/sqlwatch_logger_system_configuration_scd.sql
+++ b/SQLWATCHDB/dbo/Tables/sqlwatch_logger_system_configuration_scd.sql
@@ -1,0 +1,15 @@
+﻿CREATE TABLE [dbo].[sqlwatch_logger_system_configuration_scd]
+(
+	sql_instance varchar(32) not null default @@SERVERNAME,
+	sqlwatch_configuration_id smallint not null,
+	value int not null,
+	value_in_use int not null,
+	valid_from datetime not null constraint sqlwatch_logger_system_configuration_scd_valid_from default(getutcdate()),
+	valid_until datetime null,
+	constraint pk_sqlwatch_logger_system_configuration_scd primary key clustered (
+		sqlwatch_configuration_id, sql_instance, valid_from
+		),
+	constraint fk_sqlwatch_logger_system_configuration_scd_keyword foreign key (sql_instance, sqlwatch_configuration_id) 
+		references dbo.sqlwatch_meta_system_configuration (sql_instance, sqlwatch_configuration_id)on delete cascade
+)
+go

--- a/SQLWATCHDB/dbo/Tables/sqlwatch_meta_system_configuration.sql
+++ b/SQLWATCHDB/dbo/Tables/sqlwatch_meta_system_configuration.sql
@@ -1,0 +1,19 @@
+﻿CREATE TABLE [dbo].[sqlwatch_meta_system_configuration]
+(
+	[sqlwatch_configuration_id] smallint identity(1,1) not null,
+	[sql_instance] varchar(32) not null constraint df_sqlwatch_meta_system_configuration_sql_instance default (@@SERVERNAME),
+	[configuration_id] int not null,
+	[name] nvarchar(128) not null,
+	[description] nvarchar(512) not null,
+	[value] int not null,
+	[value_in_use] int,
+	[date_created] datetime not null constraint df_sqlwatch_meta_system_configuration_date_created default (getutcdate()),
+	[date_updated] datetime null,
+	[date_last_seen] datetime null,
+	[is_record_deleted] bit
+	constraint pk_sqlwatch_meta_system_configuration primary key clustered (
+		[sql_instance], [sqlwatch_configuration_id]
+		),
+	constraint fk_sqlwatch_meta_system_configuration foreign key ([sql_instance])
+		references [dbo].[sqlwatch_meta_server] ([servername]) on delete cascade
+)

--- a/SQLWATCHDB/dbo/Views/vw_sqlwatch_sys_configurations.sql
+++ b/SQLWATCHDB/dbo/Views/vw_sqlwatch_sys_configurations.sql
@@ -1,0 +1,26 @@
+﻿CREATE VIEW [dbo].[vw_sqlwatch_sys_configurations]
+as
+
+SELECT sql_instance = @@SERVERNAME
+     , configuration_id
+     , name
+     , CAST(value AS INT) as [value]
+     , CAST(value_in_use AS INT) as [value_in_use]
+     , description
+  FROM sys.configurations
+UNION ALL
+SELECT @@SERVERNAME
+    , -1
+    , 'version'
+    , (SELECT CAST(REPLACE(CAST(SERVERPROPERTY('productversion') AS VARCHAR(64)), '.', '') AS INT))
+    , (SELECT CAST(REPLACE(CAST(SERVERPROPERTY('productversion') AS VARCHAR(64)), '.', '') AS INT))
+    , 'Version as integer: xx.x.xxxx.xx'
+--UNION ALL
+--SELECT sql_instance = @@SERVERNAME
+--     , -2
+--     , 'instant file initialization'
+--     , CASE WHEN s.instant_file_initialization_enabled = 'Y' THEN 1 ELSE 0 END AS instant_file_initialization_enabled
+--     , CASE WHEN s.instant_file_initialization_enabled = 'Y' THEN 1 ELSE 0 END AS instant_file_initialization_enabled 
+--     , 'indicates if instant file initialization (perform volume maintenance tasks) is enabled for the SQL Server service account.'
+--  FROM sys.dm_server_services s
+-- WHERE servicename NOT LIKE 'SQL Server Agent%' AND servicename NOT LIKE 'SQL Server Launchpad%'


### PR DESCRIPTION
- View vw_sqlwatch_sys_configuration: Collection of all configuraton items that are getting captured. This view can be extended to add more configuration options
- Stored Procedures to capture meta data, snapshot data, and slowly changing data
- Table: Similar to procedure one for meta, one for sdc, and one for snapshot

Currently missing:
- Retention for slowly changing dimension.
- Power BI Page showing the information