### PR TITLE
Bug: Script.PostDeployment-CreateDefaultChecks.sql

### DIFF
--- a/SqlWatch.Monitor/Project.SqlWatch.Database/Scripts/Post-Deployment/Reference-Data/Script.PostDeployment-CreateDefaultChecks.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/Scripts/Post-Deployment/Reference-Data/Script.PostDeployment-CreateDefaultChecks.sql
@@ -479,7 +479,7 @@ exec [dbo].[usp_sqlwatch_config_add_check]
 	 @check_id = -5
 	,@check_name = 'Action queue pending items'
 	,@check_description = 'There is a large number of items awaiting action. This could indicate a problem with the action mechanism. Note that in this context, the succesful action means that the item was succesfuly executed, for example sp_send_dbmail and not that the email was delivered.'
-	,@check_query = 'select @output=count(*) from dbo.sqlwatch_meta_action_queue where exec_status is null or exec_status <> ''OK'' and time_queued < dateadd(minute,-2,getdate())'
+	,@check_query = 'select @output=count(*) from dbo.sqlwatch_meta_action_queue where exec_status is null or exec_status not in (''OK'',''ERROR'',''FAILED'') and time_queued < dateadd(minute,-2,getdate())'
 	,@check_frequency_minutes = 5
 	,@check_threshold_warning = NULL
 	,@check_threshold_critical = '>10'


### PR DESCRIPTION
There is a Bug in Check -5. 
Check raises count and failed if older queues are not waiting or long running but exec_status is Error or Failed.
Changed the Where Statement from <> 'OK' to --> not in ('OK','ERROR','FAILED')

Comment on Change in 1354 -> automated Add by Github because of no new Line on end of File

Greetings from Hamburg
Steffen