### PR TITLE
Change: Filter Name: SqlInstance Query

### DIFF
--- a/SqlWatch.Dashboard/Azure/Azure Log Analytics Workbook.json
+++ b/SqlWatch.Dashboard/Azure/Azure Log Analytics Workbook.json
@@ -83,7 +83,7 @@
             "name": "SqlInstance",
             "type": 2,
             "isRequired": true,
-            "query": "SQLWATCH_Instance_CL | top 1 by TimeGenerated | distinct sql_instance_s | where sql_instance_s != \"\" | sort by sql_instance_s",
+            "query": "SQLWATCH_Instance_CL | distinct sql_instance_s | where sql_instance_s != \"\" | sort by sql_instance_s",
             "value": null,
             "typeSettings": {
               "additionalResourceOptions": []


### PR DESCRIPTION
If "SQLWATCH_Instance_CL | top 1 by TimeGenerated...." Filter is set, only last Instance that commited Data to Log Analytics Workspace will be Shown in Filter Dropdown. This is no problem if you commit Data from your DWH, but in case of multiple Instances commiting Data on different Times to the same workspace only the most current Instance will be shown in dropdown.

Deleting this Part will show each Instance in Dropdown that has Data commited to Log Analytics Workspace within the selected Timerange of the Report Time Range.

With greetings from Hamburg
Steffen