### PR TITLE
Fix #286. I redesigned the way we store plans to make it more storage…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ project.assets.json
 SqlWatch.Monitor/.vs/SqlWatch.Monitor/DesignTimeBuild/.dtbcache.v2
 /SqlWatch.Monitor/UpgradeLog.htm
 SqlWatch.Monitor/Project.SqlWatch.Database/obj/SQLWATCHDATABASE.generated.sql
+/SqlWatch.Monitor/Project.SqlWatch.Database/bin/Release
+/SqlWatch.Monitor/Project.SqlWatch.Database/obj/Release


### PR DESCRIPTION
… efficient. We base off query_hash and plan_hash rather than handles and store the first plan and statement for the given combination of query_hash and plan_hash. In addition, we also store handles in a separate table purely to help with joins but we're not storing all query_plans for all handles as this would be pointless. Bumped the version 4.0 as this is quite a substantial change to the schema so upgrade is unlikely.