### PR TITLE
Fixed `usp_sqlwatch_internal_add_procedure` not being invoked via Broker. Fix #342

### DIFF
--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Procedures/usp_sqlwatch_internal_exec_activated.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Procedures/usp_sqlwatch_internal_exec_activated.sql
@@ -186,6 +186,7 @@ begin
                                             exec dbo.usp_sqlwatch_internal_add_memory_clerk;
                                             exec dbo.usp_sqlwatch_internal_add_wait_type;
                                             exec dbo.usp_sqlwatch_internal_add_index;
+                                            exec dbo.usp_sqlwatch_internal_add_procedure;
 
                                             --exec dbo.usp_sqlwatch_logger_disk_utilisation;
 


### PR DESCRIPTION
Adding in execution of procedure [usp_sqlwatch_internal_add_procedure]