### PR TITLE
Add ability to capture ERROLOG records based on two keywords. (!)

### DIFF
--- a/SqlWatch.Monitor/Project.SqlWatch.Database/SQLWATCH.refactorlog
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/SQLWATCH.refactorlog
@@ -2912,4 +2912,18 @@
     <Property Name="ParentElementType" Value="SqlTable" />
     <Property Name="NewName" Value="last_event_time" />
   </Operation>
+  <Operation Name="Rename Refactor" Key="5de2882f-1651-47d0-b8a0-2e3880897931" ChangeDateTime="05/17/2021 11:55:37">
+    <Property Name="ElementName" Value="[dbo].[sqlwatch_config_include_errorlog_keywords].[keyword]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[sqlwatch_config_include_errorlog_keywords]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="keyword1" />
+  </Operation>
+  <Operation Name="Rename Refactor" Key="4a0d5d0d-5dba-4720-be0f-37b1edbee718" ChangeDateTime="05/17/2021 13:51:07">
+    <Property Name="ElementName" Value="[dbo].[sqlwatch_meta_errorlog_keyword].[keyword]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[sqlwatch_meta_errorlog_keyword]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="keyword1" />
+  </Operation>
 </Operations>

--- a/SqlWatch.Monitor/Project.SqlWatch.Database/Scripts/Post-Deployment/Reference-Data/Script.PostDeployment-LoadConfig-DefaultErrorLog.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/Scripts/Post-Deployment/Reference-Data/Script.PostDeployment-LoadConfig-DefaultErrorLog.sql
@@ -10,26 +10,46 @@ Post-Deployment Script Template
 --------------------------------------------------------------------------------------
 */
 
+declare @keywords table (
+    [keyword1] nvarchar(255) not null,
+    [keyword2] nvarchar(255) null,
+    [log_type_id] int not null
+);
+
 --only do this on the fresh install becuase the end user could have removed our default records, we do not want to reload them
 if (select count(*) from dbo.sqlwatch_app_version) < 1
     begin
-        declare @keywords table (
-            [keyword] nvarchar(255) not null,
-            [log_type_id] int not null
-        );
-
-        insert into @keywords
-        values  ('Login failed for user', 1),
-                ('I/O saturation', 1),
-                ('I/O requests', 1)
+        insert into @keywords (keyword1, keyword2, log_type_id)
+        values  ('Login failed for user', null,1)
         ;
 
         merge [dbo].[sqlwatch_config_include_errorlog_keywords] as target
         using @keywords as source 
-        on source.[keyword] = target.[keyword]
+        on source.[keyword1] = target.[keyword1]
+        and isnull(source.[keyword2],'') = isnull(target.[keyword2],'')
         and source.[log_type_id] = target.[log_type_id]
         
         when not matched then 
-            insert ([keyword], [log_type_id])
-            values (source.[keyword], source.[log_type_id]);
+            insert (keyword1, [keyword2], [log_type_id])
+            values (source.[keyword1], source.[keyword2], source.[log_type_id]);
     end;
+
+--We need this all the time, if the user deleted it, we have to add it back in:
+delete from @keywords;
+
+insert into @keywords (keyword1, keyword2, log_type_id)
+values  ('I/O saturation', null,1),
+        ('I/O requests', null,1),
+        ('sqlwatch_exec', 'Error',1),
+        ('sqlwatch_exec', 'failed',1)
+        ;
+
+merge [dbo].[sqlwatch_config_include_errorlog_keywords] as target
+using @keywords as source 
+on source.[keyword1] = target.[keyword1]
+and isnull(source.[keyword2],'') = isnull(target.[keyword2],'')
+and source.[log_type_id] = target.[log_type_id]
+        
+when not matched then 
+    insert (keyword1, [keyword2], [log_type_id])
+    values (source.[keyword1], source.[keyword2], source.[log_type_id]);

--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Procedures/usp_sqlwatch_internal_exec_activated.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Procedures/usp_sqlwatch_internal_exec_activated.sql
@@ -191,8 +191,8 @@ begin
                                             --exec dbo.usp_sqlwatch_logger_disk_utilisation;
 
                                             --trends:
-                                            exec dbo.usp_sqlwatch_trend_perf_os_performance_counters @interval_minutes = 1, @valid_days = 7
-                                            exec dbo.usp_sqlwatch_trend_perf_os_performance_counters @interval_minutes = 5, @valid_days = 90
+                                            exec dbo.usp_sqlwatch_trend_perf_os_performance_counters @interval_minutes = 1, @valid_days = 7;
+                                            exec dbo.usp_sqlwatch_trend_perf_os_performance_counters @interval_minutes = 5, @valid_days = 90;
                                             exec dbo.usp_sqlwatch_trend_perf_os_performance_counters @interval_minutes = 60, @valid_days = 720;
                                         end try
                                         begin catch
@@ -214,6 +214,7 @@ begin
                                         exec [dbo].[usp_sqlwatch_internal_exec_activated_async] @procedure_name = 'dbo.usp_sqlwatch_internal_purge_deleted_items';
                                         exec [dbo].[usp_sqlwatch_internal_exec_activated_async] @procedure_name = 'dbo.usp_sqlwatch_internal_expand_checks';
                                         exec [dbo].[usp_sqlwatch_internal_exec_activated_async] @procedure_name = 'dbo.usp_sqlwatch_internal_add_index_missing';
+                                        exec [dbo].[usp_sqlwatch_internal_exec_activated_async] @procedure_name = 'dbo.usp_sqlwatch_logger_errorlog';
 
                                         set @process_message = 'Message Type: ' + convert(varchar(4000),@message_type_name) + '; Timer: ' + convert(varchar(5),@timer) + '; Time Taken: ' + convert(varchar(100),datediff(ms,@timestart,SYSDATETIME()))  + 'ms'
 

--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Procedures/usp_sqlwatch_logger_errorlog.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Procedures/usp_sqlwatch_logger_errorlog.sql
@@ -37,7 +37,7 @@ where m.sql_instance = @@SERVERNAME;
 
 open c_parse_errorlog
 
-fetch next from c_parse_errorlog into @keyword_id, @keyword1, @keyword2, @log_type_id
+fetch next from c_parse_errorlog into @keyword_id, @keyword1, @keyword2, @log_type_id;
 
 while @@FETCH_STATUS = 0
 	begin

--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_config_include_errorlog_keywords.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_config_include_errorlog_keywords.sql
@@ -1,8 +1,21 @@
 ﻿CREATE TABLE [dbo].[sqlwatch_config_include_errorlog_keywords]
 (
-	keyword nvarchar(255),
-	log_type_id int,
+	keyword_id int identity(1,1) not null,
+	keyword1 nvarchar(255) not null,
+	keyword2 nvarchar(255) null,
+	log_type_id int not null,
 	constraint pk_sqlwatch_config_include_errorlog_keywords primary key clustered (
-		keyword, log_type_id
+		keyword_id, log_type_id
 		)
-)
+);
+go
+
+create unique nonclustered index idx_sqlwatch_config_include_errorlog_keywords_keyword1
+on [dbo].[sqlwatch_config_include_errorlog_keywords]  (keyword1)
+where keyword2  is null;
+go
+
+create unique nonclustered index idx_sqlwatch_config_include_errorlog_keywords_keyword2
+on [dbo].[sqlwatch_config_include_errorlog_keywords]  (keyword1, keyword2)
+where keyword2  is not null;
+go

--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_logger_errorlog.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_logger_errorlog.sql
@@ -17,9 +17,9 @@
 
 	constraint fk_sqlwatch_logger_errorlog_snapshot foreign key ([snapshot_time], [sql_instance], [snapshot_type_id])
 		references dbo.sqlwatch_logger_snapshot_header ([snapshot_time], [sql_instance], [snapshot_type_id]) on delete cascade
-)
+);
 go
 
 create nonclustered index idx_sqlwatch_logger_errorlog_1 on [dbo].[sqlwatch_logger_errorlog] (
 	keyword_id, log_type_id, sql_instance
-	) include (log_date)
+	) include (log_date);

--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_meta_errorlog_keyword.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_meta_errorlog_keyword.sql
@@ -1,9 +1,10 @@
 ﻿CREATE TABLE [dbo].[sqlwatch_meta_errorlog_keyword]
 (
 	sql_instance varchar(32) not null,
-	keyword_id smallint identity(1,1) not null,
+	keyword_id smallint not null,-- identity(1,1) ,
 	log_type_id int not null,
-	keyword nvarchar(255),
+	keyword1 nvarchar(255),
+	keyword2 nvarchar(255),
 	[date_updated] datetime not null constraint df_sqlwatch_meta_errorlog_keyword_updated default (getutcdate()),
 	constraint pk_sqlwatch_meta_errorlog_keyword primary key clustered (
 		sql_instance, keyword_id, log_type_id
@@ -13,7 +14,7 @@
 )
 go
 
-create nonclustered index idx_sqlwatch_meta_errorlog_keyword_1 on [dbo].[sqlwatch_meta_errorlog_keyword] (keyword)
+create nonclustered index idx_sqlwatch_meta_errorlog_keyword_1 on [dbo].[sqlwatch_meta_errorlog_keyword] (keyword1)
 	include (sql_instance, keyword_id, log_type_id)
 go
 

--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Views/vw_sqlwatch_logger_errorlog.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Views/vw_sqlwatch_logger_errorlog.sql
@@ -10,7 +10,8 @@ SELECT le.[sql_instance]
 	  , ea.attribute_name
 	  , ea.attribute_value
 	  , et.errorlog_text
-      , ek.keyword
+      , ek.keyword1
+	  , ek.keyword2
   FROM [dbo].[sqlwatch_logger_errorlog] le
   inner join [dbo].[sqlwatch_meta_errorlog_attribute] ea
 	on ea.[sql_instance] = le.sql_instance
@@ -20,4 +21,4 @@ SELECT le.[sql_instance]
 	and et.[errorlog_text_id] = le.[errorlog_text_id]
   inner join dbo.sqlwatch_meta_errorlog_keyword ek
 	on ek.sql_instance = le.sql_instance
-	and ek.keyword_id = le.keyword_id
+	and ek.keyword_id = le.keyword_id;


### PR DESCRIPTION
This change required moving identity column from meta to config table. After deployment, it may be required to run the logger procedure and remove any meta records that have invalid IDs:

```
exec dbo.usp_sqlwatch_logger_errorlog;

delete m
from dbo.sqlwatch_meta_errorlog_keyword m
left join dbo.sqlwatch_config_include_errorlog_keywords c
 on m.keyword_id = c.keyword_id
where c.keyword_id is null
```
This may also remove some records from the logger table. You may want to make a copy of the `sqlwatch_logger_errorlog` table if you care about the content.