### PR TITLE
Update usp_sqlwatch_logger_xes_blockers.sql

### DIFF
--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Procedures/usp_sqlwatch_logger_xes_blockers.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Procedures/usp_sqlwatch_logger_xes_blockers.sql
@@ -5,7 +5,7 @@ set nocount on;
 set xact_abort on;
 
 declare @execution_count bigint = 0,
-		@session_name nvarchar(64) = 'SQLWATCH_Blockers',
+		@session_name nvarchar(64) = 'SQLWATCH_blockers',
 		@snapshot_time datetime,
 		@snapshot_type_id tinyint = 9,
 		@filename varchar(8000),


### PR DESCRIPTION
Fix for usp_sqlwatch_logger_xes_blockers stored procedure if SQL Server uses binary collation.